### PR TITLE
Update example-ip-blacklist.txt

### DIFF
--- a/dnscrypt-proxy/example-ip-blacklist.txt
+++ b/dnscrypt-proxy/example-ip-blacklist.txt
@@ -10,4 +10,4 @@
 
 163.5.1.4
 94.46.118.*
-[fe80:53:*]        # IPv6 prefix example
+fe80:53:*          # IPv6 prefix example


### PR DESCRIPTION
fix https://github.com/DNSCrypt/dnscrypt-proxy/issues/1261. remove `[` & `]`.